### PR TITLE
Clarifaispark v2

### DIFF
--- a/clarifaipyspark/dataset.py
+++ b/clarifaipyspark/dataset.py
@@ -33,6 +33,9 @@ class Dataset(Dataset):
     self.user_id = user_id
     self.app_id = app_id
     self.dataset_id = dataset_id
+    self.spark = spark = SparkSession.builder.appName('Clarifai-pyspark').getOrCreate()
+    # Set Databricks user agent tag
+    self.spark.conf.set("spark.databricks.agent.id", "clarifaipyspark")
     super().__init__(user_id=user_id, app_id=app_id, dataset_id=dataset_id, pat=pat)
 
   def upload_dataset_from_csv(self,
@@ -69,8 +72,7 @@ class Dataset(Dataset):
           labels=labels,
           batch_size=batch_size)
     elif source == "s3":
-      spark = SparkSession.builder.appName('Clarifai-spark').getOrCreate()
-      df_csv = spark.read.format("csv").option('header', 'true').load(csv_path)
+      df_csv = self.spark.read.format("csv").option('header', 'true').load(csv_path)
       self.upload_dataset_from_dataframe(
           dataframe=df_csv,
           input_type=input_type,
@@ -257,8 +259,7 @@ class Dataset(Dataset):
 
     Example: TODO
     """
-    spark = SparkSession.builder.appName('Clarifai-spark').getOrCreate()
-    tempdf = spark.read.format("delta").load(table_path)
+    tempdf = self.spark.read.format("delta").load(table_path)
     self.upload_dataset_from_dataframe(
         dataframe=tempdf,
         input_type=input_type,
@@ -326,7 +327,6 @@ class Dataset(Dataset):
     """
 
     annotation_list = []
-    spark = SparkSession.builder.appName('Clarifai-spark').getOrCreate()
     response = list(self.list_annotations(input_ids=input_ids, input_type=input_type))
     for an in response:
       temp = {}
@@ -346,7 +346,7 @@ class Dataset(Dataset):
         temp['annotation_created_at'] = float(f"{an.created_at.seconds}.{an.created_at.nanos}")
         temp['annotation_modified_at'] = float(f"{an.modified_at.seconds}.{an.modified_at.nanos}")
       annotation_list.append(temp)
-    return spark.createDataFrame(annotation_list)
+    return self.spark.createDataFrame(annotation_list)
 
   def export_images_to_volume(self, path, input_response):
     """Download all the images from clarifai App's dataset to spark volume storage.
@@ -409,7 +409,6 @@ class Dataset(Dataset):
     if input_type not in ('image', 'text'):
       raise UserError('Invalid input type, it should be image or text')
     input_list = []
-    spark = SparkSession.builder.appName('Clarifai-spark').getOrCreate()
     response = list(self.list_inputs(input_type=input_type))
     for inp in response:
       temp = {}
@@ -429,7 +428,7 @@ class Dataset(Dataset):
         temp['input_created_at'] = float(f"{inp.created_at.seconds}.{inp.created_at.nanos}")
         temp['input_modified_at'] = float(f"{inp.modified_at.seconds}.{inp.modified_at.nanos}")
       input_list.append(temp)
-    return spark.createDataFrame(input_list)
+    return self.spark.createDataFrame(input_list)
 
   def export_dataset_to_dataframe(self, input_type, input_ids: list = None):
     """Export all the inputs & their annotations from clarifai App's dataset to spark dataframe.

--- a/clarifaipyspark/dataset.py
+++ b/clarifaipyspark/dataset.py
@@ -33,7 +33,7 @@ class Dataset(Dataset):
     self.user_id = user_id
     self.app_id = app_id
     self.dataset_id = dataset_id
-    self.spark = spark = SparkSession.builder.appName('Clarifai-pyspark').getOrCreate()
+    self.spark = SparkSession.builder.appName('Clarifai-pyspark').getOrCreate()
     # Set Databricks user agent tag
     self.spark.conf.set("spark.databricks.agent.id", "clarifaipyspark")
     super().__init__(user_id=user_id, app_id=app_id, dataset_id=dataset_id, pat=pat)

--- a/clarifaipyspark/dataset.py
+++ b/clarifaipyspark/dataset.py
@@ -35,7 +35,7 @@ class Dataset(Dataset):
     self.dataset_id = dataset_id
     self.spark = SparkSession.builder.appName('Clarifai-pyspark').getOrCreate()
     # Set Databricks user agent tag
-    self.spark.conf.set("spark.databricks.agent.id", "clarifaipyspark")
+    self.spark.conf.set("spark.databricks.agent.id", "clarifai-pyspark")
     super().__init__(user_id=user_id, app_id=app_id, dataset_id=dataset_id, pat=pat)
 
   def upload_dataset_from_csv(self,

--- a/examples/ClarifaiPyspark_Example_NB.ipynb
+++ b/examples/ClarifaiPyspark_Example_NB.ipynb
@@ -573,6 +573,24 @@
    "source": [
     "dataset_df = dataset_obj.export_dataset_to_dataframe()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### D. Export annotations with their associated images into databricks volume folder\n",
+    "Additionally you can export both annotations and it's associated images into single folder inside databricks volume using the below function.                          \n",
+    "Just provide the {volume_path}/{folder_name} as input string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_obj.export_annotations_to_volume(volumepath=\"destination_volume_path\",)"
+   ]
   }
  ],
  "metadata": {

--- a/examples/ClarifaiPyspark_demobook.ipynb
+++ b/examples/ClarifaiPyspark_demobook.ipynb
@@ -614,7 +614,8 @@
     }
    ],
    "source": [
-    "spark = SparkSession.builder.appName(\"Clarifai-spark\").getOrCreate()\n",
+    "spark = SparkSession.builder.appName(\"Clarifai-pyspark\").getOrCreate()\n",
+    "spark.conf.set(\"spark.databricks.agent.id\", \"clarifaipyspark\")\n",
     "df_delta = spark.read.format(\"delta\").load(\"/Volumes/mansi_test/default/test_vol1/imgAnnsDeltaTable2\")\n",
     "df_delta.show()"
    ]
@@ -846,7 +847,8 @@
     }
    ],
    "source": [
-    "spark = SparkSession.builder.appName(\"Clarifai-spark\").getOrCreate()\n",
+    "spark = SparkSession.builder.appName(\"Clarifai-pyspark\").getOrCreate()\n",
+    "spark.conf.set(\"spark.databricks.agent.id\", \"clarifaipyspark\")\n",
     "df = spark.read.option(\"header\",True).csv(\"/Volumes/mansi_test/default/test_vol1/img_data2.csv\")\n",
     "df.show()"
    ]
@@ -1447,7 +1449,8 @@
     }
    ],
    "source": [
-    "spark = SparkSession.builder.appName(\"Clarifai-spark\").getOrCreate()\n",
+    "spark = SparkSession.builder.appName(\"Clarifai-pyspark\").getOrCreate()\n",
+    "spark.conf.set(\"spark.databricks.agent.id\", \"clarifaipyspark\")\n",
     "df = spark.read.option(\"header\",True).csv(\"/Volumes/mansi_test/default/test_vol1/emotions_data1.csv\")\n",
     "df.show()"
    ]

--- a/examples/ClarifaiPyspark_demobook.ipynb
+++ b/examples/ClarifaiPyspark_demobook.ipynb
@@ -615,7 +615,7 @@
    ],
    "source": [
     "spark = SparkSession.builder.appName(\"Clarifai-pyspark\").getOrCreate()\n",
-    "spark.conf.set(\"spark.databricks.agent.id\", \"clarifaipyspark\")\n",
+    "spark.conf.set(\"spark.databricks.agent.id\", \"clarifai-pyspark\")\n",
     "df_delta = spark.read.format(\"delta\").load(\"/Volumes/mansi_test/default/test_vol1/imgAnnsDeltaTable2\")\n",
     "df_delta.show()"
    ]
@@ -848,7 +848,7 @@
    ],
    "source": [
     "spark = SparkSession.builder.appName(\"Clarifai-pyspark\").getOrCreate()\n",
-    "spark.conf.set(\"spark.databricks.agent.id\", \"clarifaipyspark\")\n",
+    "spark.conf.set(\"spark.databricks.agent.id\", \"clarifai-pyspark\")\n",
     "df = spark.read.option(\"header\",True).csv(\"/Volumes/mansi_test/default/test_vol1/img_data2.csv\")\n",
     "df.show()"
    ]
@@ -1450,7 +1450,7 @@
    ],
    "source": [
     "spark = SparkSession.builder.appName(\"Clarifai-pyspark\").getOrCreate()\n",
-    "spark.conf.set(\"spark.databricks.agent.id\", \"clarifaipyspark\")\n",
+    "spark.conf.set(\"spark.databricks.agent.id\", \"clarifai-pyspark\")\n",
     "df = spark.read.option(\"header\",True).csv(\"/Volumes/mansi_test/default/test_vol1/emotions_data1.csv\")\n",
     "df.show()"
    ]

--- a/examples/delta_live_table_upsert_demo.ipynb
+++ b/examples/delta_live_table_upsert_demo.ipynb
@@ -209,6 +209,7 @@
     "from pyspark.sql import SparkSession\n",
     "\n",
     "spark = SparkSession.builder.appName(\"Delta Live Table Demo\").getOrCreate()\n",
+    "spark.conf.set(\"spark.databricks.agent.id\", \"clarifaipyspark\")\n",
     "database_name = \"db_test\"\n",
     "table_name = \"dlt_anns2\"\n",
     "delta_path = \"/mnt/delta_anns2\"\n",

--- a/examples/delta_live_table_upsert_demo.ipynb
+++ b/examples/delta_live_table_upsert_demo.ipynb
@@ -209,7 +209,7 @@
     "from pyspark.sql import SparkSession\n",
     "\n",
     "spark = SparkSession.builder.appName(\"Delta Live Table Demo\").getOrCreate()\n",
-    "spark.conf.set(\"spark.databricks.agent.id\", \"clarifaipyspark\")\n",
+    "spark.conf.set(\"spark.databricks.agent.id\", \"clarifai-pyspark\")\n",
     "database_name = \"db_test\"\n",
     "table_name = \"dlt_anns2\"\n",
     "delta_path = \"/mnt/delta_anns2\"\n",


### PR DESCRIPTION
## Added export_annotations_to_volume function,
 https://clarifai.atlassian.net/browse/DEVX-307

1. It fetches annotation from the clarifai app and the respective annotated images and store it in a UC volume under same folder that we mention while executing the function.

Previously we had 2 separate functions which performs export of annotations and export of images, but while exporting images it exports images irrespective of annotated or non-annotated image. 
