### PR TITLE
Delta table notebook changes

### DIFF
--- a/examples/ClarifaiPyspark_Example_NB.ipynb
+++ b/examples/ClarifaiPyspark_Example_NB.ipynb
@@ -434,7 +434,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "inputs_df = dataset_obj.export_inputs_to_dataframe(input_type=\"text/image\")"
+    "inputs_df = dataset_obj.export_inputs_to_dataframe(input_type=\"text/image\")\n",
+    "inputs_df.write.mode(\"overwrite\").saveAsTable(\"MyDeltaTable0\")"
    ]
   },
   {
@@ -545,7 +546,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "annotations_df = dataset_obj.export_annotations_to_dataframe(input_ids=None)"
+    "annotations_df = dataset_obj.export_annotations_to_dataframe(input_ids=None)\n",
+    "annotations_df.write.mode(\"overwrite\").saveAsTable(\"MyDeltaTable1\")"
    ]
   },
   {
@@ -571,7 +573,8 @@
    },
    "outputs": [],
    "source": [
-    "dataset_df = dataset_obj.export_dataset_to_dataframe()"
+    "dataset_df = dataset_obj.export_dataset_to_dataframe()\n",
+    "dataset_df.write.mode(\"overwrite\").saveAsTable(\"MyDeltaTable2\")"
    ]
   },
   {
@@ -600,7 +603,7 @@
    "notebookMetadata": {
     "pythonIndentUnit": 4
    },
-   "notebookName": "ClarifaiPyspark Example NB",
+   "notebookName": "ClarifaiPyspark_Example_NB",
    "widgets": {}
   },
   "language_info": {

--- a/examples/ClarifaiPyspark_demobook.ipynb
+++ b/examples/ClarifaiPyspark_demobook.ipynb
@@ -49,6 +49,27 @@
       "rowLimit": 10000
      },
      "inputWidgets": {},
+     "nuid": "71ae162d-45cc-44c4-bfc5-524cf979c5e2",
+     "showTitle": false,
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from clarifaipyspark.client import ClarifaiPySpark\n",
+    "from pyspark.sql import SparkSession"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
      "nuid": "c6c40e27-74cc-400c-b287-ef4946ec9f13",
      "showTitle": false,
      "title": ""
@@ -58,11 +79,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-11-17 10:47:29 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-12-15 09:35:51 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m2023-11-17 10:47:29\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=690049;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=59966;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001b[2;36m2023-12-15 09:35:51\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=482847;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=4919;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
       ]
      },
      "metadata": {},
@@ -70,9 +91,6 @@
     }
    ],
    "source": [
-    "from clarifaipyspark.client import ClarifaiPySpark\n",
-    "from pyspark.sql import SparkSession\n",
-    "\n",
     "CLARIFAI_PAT = dbutils.secrets.get(scope=\"clarifai\", key=\"clarifai-pat\")"
    ]
   },
@@ -80,7 +98,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "f1d7478c-e90a-4060-aeac-4fd9c302e147",
      "showTitle": false,
@@ -110,11 +131,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-11-17 10:37:00 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-12-15 09:35:56 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m2023-11-17 10:37:00\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=424539;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=746841;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001b[2;36m2023-12-15 09:35:56\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=98778;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=207291;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
       ]
      },
      "metadata": {},
@@ -131,7 +152,48 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "76a4ffe7-3a47-42ad-84db-1126aacd9cb1",
+     "showTitle": false,
+     "title": ""
+    }
+   },
+   "source": [
+    "### Upload images from volume folder to Clarifai dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "d15b3001-8b49-498b-b7c3-60d775047671",
+     "showTitle": false,
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dataset_obj.upload_dataset_from_folder(folder_path='/Volumes/mansi_test/default/cat', input_type='image', labels=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "37067eee-62ff-484c-9748-e4a29ae8103c",
      "showTitle": false,
@@ -161,11 +223,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-11-17 10:39:52 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m2023-11-17 10:39:52\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=653630;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=683346;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=996121;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=562137;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
       ]
      },
      "metadata": {},
@@ -174,7 +236,514 @@
     {
      "data": {
       "text/plain": [
-       "[id: \"c10\"\n",
+       "[id: \"img31\"\n",
+       " data {\n",
+       "   image {\n",
+       "     url: \"https://mymodernmet.com/wp/wp-content/uploads/2023/01/how-to-draw-a-duck-fb-thumbnail.jpg\"\n",
+       "     hosted {\n",
+       "       prefix: \"https://data.clarifai.com\"\n",
+       "       suffix: \"users/mansi_k/apps/databricks_tester_img/inputs/image/2d7a8f8aeb24b42bdae2dce75fdecb6d\"\n",
+       "       sizes: \"orig\"\n",
+       "       sizes: \"tiny\"\n",
+       "       sizes: \"small\"\n",
+       "       sizes: \"large\"\n",
+       "       crossorigin: \"use-credentials\"\n",
+       "     }\n",
+       "     image_info {\n",
+       "       width: 1200\n",
+       "       height: 630\n",
+       "       format: \"JPEG\"\n",
+       "       color_mode: \"YUV\"\n",
+       "     }\n",
+       "   }\n",
+       "   concepts {\n",
+       "     id: \"id-duck\"\n",
+       "     name: \"duck\"\n",
+       "     value: 1\n",
+       "     app_id: \"databricks_tester_img\"\n",
+       "   }\n",
+       " }\n",
+       " created_at {\n",
+       "   seconds: 1702316868\n",
+       "   nanos: 297862000\n",
+       " }\n",
+       " modified_at {\n",
+       "   seconds: 1702316869\n",
+       "   nanos: 507025000\n",
+       " }\n",
+       " status {\n",
+       "   code: INPUT_DOWNLOAD_SUCCESS\n",
+       "   description: \"Download complete\"\n",
+       " },\n",
+       " id: \"dataset1-train-3647386\"\n",
+       " data {\n",
+       "   image {\n",
+       "     url: \"https://data.clarifai.com/orig/users/mansi_k/apps/databricks_tester_img/inputs/image/1249d3d8c8157d1b2dcdb2561175374a\"\n",
+       "     hosted {\n",
+       "       prefix: \"https://data.clarifai.com\"\n",
+       "       suffix: \"users/mansi_k/apps/databricks_tester_img/inputs/image/1249d3d8c8157d1b2dcdb2561175374a\"\n",
+       "       sizes: \"orig\"\n",
+       "       sizes: \"tiny\"\n",
+       "       sizes: \"small\"\n",
+       "       sizes: \"large\"\n",
+       "       crossorigin: \"use-credentials\"\n",
+       "     }\n",
+       "     image_info {\n",
+       "       width: 512\n",
+       "       height: 288\n",
+       "       format: \"JPEG\"\n",
+       "       color_mode: \"YUV\"\n",
+       "     }\n",
+       "   }\n",
+       "   concepts {\n",
+       "     id: \"id-hamburger\"\n",
+       "     name: \"hamburger\"\n",
+       "     value: 1\n",
+       "     app_id: \"databricks_tester_img\"\n",
+       "   }\n",
+       " }\n",
+       " created_at {\n",
+       "   seconds: 1700218110\n",
+       "   nanos: 681462000\n",
+       " }\n",
+       " modified_at {\n",
+       "   seconds: 1700218111\n",
+       "   nanos: 623206000\n",
+       " }\n",
+       " status {\n",
+       "   code: INPUT_DOWNLOAD_SUCCESS\n",
+       "   description: \"Download complete\"\n",
+       " },\n",
+       " id: \"dataset1-train-3520891\"\n",
+       " data {\n",
+       "   image {\n",
+       "     url: \"https://data.clarifai.com/orig/users/mansi_k/apps/databricks_tester_img/inputs/image/2b6cb268add3efb714e702699ff54ed9\"\n",
+       "     hosted {\n",
+       "       prefix: \"https://data.clarifai.com\"\n",
+       "       suffix: \"users/mansi_k/apps/databricks_tester_img/inputs/image/2b6cb268add3efb714e702699ff54ed9\"\n",
+       "       sizes: \"orig\"\n",
+       "       sizes: \"tiny\"\n",
+       "       sizes: \"small\"\n",
+       "       sizes: \"large\"\n",
+       "       crossorigin: \"use-credentials\"\n",
+       "     }\n",
+       "     image_info {\n",
+       "       width: 512\n",
+       "       height: 512\n",
+       "       format: \"JPEG\"\n",
+       "       color_mode: \"YUV\"\n",
+       "     }\n",
+       "   }\n",
+       "   concepts {\n",
+       "     id: \"id-ramen\"\n",
+       "     name: \"ramen\"\n",
+       "     value: 1\n",
+       "     app_id: \"databricks_tester_img\"\n",
+       "   }\n",
+       " }\n",
+       " created_at {\n",
+       "   seconds: 1700218110\n",
+       "   nanos: 681462000\n",
+       " }\n",
+       " modified_at {\n",
+       "   seconds: 1700218111\n",
+       "   nanos: 623206000\n",
+       " }\n",
+       " status {\n",
+       "   code: INPUT_DOWNLOAD_SUCCESS\n",
+       "   description: \"Download complete\"\n",
+       " },\n",
+       " id: \"dataset1-train-3385808\"\n",
+       " data {\n",
+       "   image {\n",
+       "     url: \"https://data.clarifai.com/orig/users/mansi_k/apps/databricks_tester_img/inputs/image/5835a13c322548a67038ca2d191dc7bf\"\n",
+       "     hosted {\n",
+       "       prefix: \"https://data.clarifai.com\"\n",
+       "       suffix: \"users/mansi_k/apps/databricks_tester_img/inputs/image/5835a13c322548a67038ca2d191dc7bf\"\n",
+       "       sizes: \"orig\"\n",
+       "       sizes: \"tiny\"\n",
+       "       sizes: \"small\"\n",
+       "       sizes: \"large\"\n",
+       "       crossorigin: \"use-credentials\"\n",
+       "     }\n",
+       "     image_info {\n",
+       "       width: 512\n",
+       "       height: 384\n",
+       "       format: \"JPEG\"\n",
+       "       color_mode: \"YUV\"\n",
+       "     }\n",
+       "   }\n",
+       "   concepts {\n",
+       "     id: \"id-hamburger\"\n",
+       "     name: \"hamburger\"\n",
+       "     value: 1\n",
+       "     app_id: \"databricks_tester_img\"\n",
+       "   }\n",
+       " }\n",
+       " created_at {\n",
+       "   seconds: 1700218110\n",
+       "   nanos: 681462000\n",
+       " }\n",
+       " modified_at {\n",
+       "   seconds: 1700218111\n",
+       "   nanos: 623206000\n",
+       " }\n",
+       " status {\n",
+       "   code: INPUT_DOWNLOAD_SUCCESS\n",
+       "   description: \"Download complete\"\n",
+       " },\n",
+       " id: \"dataset1-train-2427642\"\n",
+       " data {\n",
+       "   image {\n",
+       "     url: \"https://data.clarifai.com/orig/users/mansi_k/apps/databricks_tester_img/inputs/image/423d388febb5576e5b7fa55f00511b5c\"\n",
+       "     hosted {\n",
+       "       prefix: \"https://data.clarifai.com\"\n",
+       "       suffix: \"users/mansi_k/apps/databricks_tester_img/inputs/image/423d388febb5576e5b7fa55f00511b5c\"\n",
+       "       sizes: \"orig\"\n",
+       "       sizes: \"tiny\"\n",
+       "       sizes: \"small\"\n",
+       "       sizes: \"large\"\n",
+       "       crossorigin: \"use-credentials\"\n",
+       "     }\n",
+       "     image_info {\n",
+       "       width: 512\n",
+       "       height: 384\n",
+       "       format: \"JPEG\"\n",
+       "       color_mode: \"YUV\"\n",
+       "     }\n",
+       "   }\n",
+       "   concepts {\n",
+       "     id: \"id-ramen\"\n",
+       "     name: \"ramen\"\n",
+       "     value: 1\n",
+       "     app_id: \"databricks_tester_img\"\n",
+       "   }\n",
+       " }\n",
+       " created_at {\n",
+       "   seconds: 1700218110\n",
+       "   nanos: 681462000\n",
+       " }\n",
+       " modified_at {\n",
+       "   seconds: 1700218111\n",
+       "   nanos: 623206000\n",
+       " }\n",
+       " status {\n",
+       "   code: INPUT_DOWNLOAD_SUCCESS\n",
+       "   description: \"Download complete\"\n",
+       " },\n",
+       " id: \"img11\"\n",
+       " data {\n",
+       "   image {\n",
+       "     url: \"https://img.freepik.com/free-photo/isolated-happy-smiling-dog-white-background-portrait-4_1562-693.jpg\"\n",
+       "     hosted {\n",
+       "       prefix: \"https://data.clarifai.com\"\n",
+       "       suffix: \"users/mansi_k/apps/databricks_tester_img/inputs/image/975f6c972d9029f9431e1e18274b121d\"\n",
+       "       sizes: \"orig\"\n",
+       "       sizes: \"tiny\"\n",
+       "       sizes: \"small\"\n",
+       "       sizes: \"large\"\n",
+       "       crossorigin: \"use-credentials\"\n",
+       "     }\n",
+       "     image_info {\n",
+       "       width: 626\n",
+       "       height: 417\n",
+       "       format: \"JPEG\"\n",
+       "       color_mode: \"YUV\"\n",
+       "     }\n",
+       "   }\n",
+       "   concepts {\n",
+       "     id: \"id-dog\"\n",
+       "     name: \"dog\"\n",
+       "     value: 1\n",
+       "     app_id: \"databricks_tester_img\"\n",
+       "   }\n",
+       " }\n",
+       " created_at {\n",
+       "   seconds: 1700218083\n",
+       "   nanos: 300441000\n",
+       " }\n",
+       " modified_at {\n",
+       "   seconds: 1700218084\n",
+       "   nanos: 397279000\n",
+       " }\n",
+       " status {\n",
+       "   code: INPUT_DOWNLOAD_SUCCESS\n",
+       "   description: \"Download complete\"\n",
+       " },\n",
+       " id: \"img21\"\n",
+       " data {\n",
+       "   image {\n",
+       "     url: \"https://images.unsplash.com/photo-1563409236302-8442b5e644df?auto=format&fit=crop&q=80&w=1000&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8M3x8ZHVja3xlbnwwfHwwfHx8MA%3D%3D\"\n",
+       "     hosted {\n",
+       "       prefix: \"https://data.clarifai.com\"\n",
+       "       suffix: \"users/mansi_k/apps/databricks_tester_img/inputs/image/6c30aa65cf64b63eba8bca9a1f6b8724\"\n",
+       "       sizes: \"orig\"\n",
+       "       sizes: \"tiny\"\n",
+       "       sizes: \"small\"\n",
+       "       sizes: \"large\"\n",
+       "       crossorigin: \"use-credentials\"\n",
+       "     }\n",
+       "     image_info {\n",
+       "       width: 1000\n",
+       "       height: 1498\n",
+       "       format: \"JPEG\"\n",
+       "       color_mode: \"YUV\"\n",
+       "     }\n",
+       "   }\n",
+       "   concepts {\n",
+       "     id: \"id-duck\"\n",
+       "     name: \"duck\"\n",
+       "     value: 1\n",
+       "     app_id: \"databricks_tester_img\"\n",
+       "   }\n",
+       " }\n",
+       " created_at {\n",
+       "   seconds: 1700218083\n",
+       "   nanos: 300441000\n",
+       " }\n",
+       " modified_at {\n",
+       "   seconds: 1700218084\n",
+       "   nanos: 397279000\n",
+       " }\n",
+       " status {\n",
+       "   code: INPUT_DOWNLOAD_SUCCESS\n",
+       "   description: \"Download complete\"\n",
+       " },\n",
+       " id: \"c6\"\n",
+       " data {\n",
+       "   image {\n",
+       "     url: \"https://data.clarifai.com/orig/users/mansi_k/apps/databricks_tester_img/inputs/image/9aad344c32108b9c7c1c54e58a3b90e3\"\n",
+       "     hosted {\n",
+       "       prefix: \"https://data.clarifai.com\"\n",
+       "       suffix: \"users/mansi_k/apps/databricks_tester_img/inputs/image/9aad344c32108b9c7c1c54e58a3b90e3\"\n",
+       "       sizes: \"orig\"\n",
+       "       sizes: \"tiny\"\n",
+       "       sizes: \"small\"\n",
+       "       sizes: \"large\"\n",
+       "       crossorigin: \"use-credentials\"\n",
+       "     }\n",
+       "     image_info {\n",
+       "       width: 612\n",
+       "       height: 640\n",
+       "       format: \"JPEG\"\n",
+       "       color_mode: \"YUV\"\n",
+       "     }\n",
+       "   }\n",
+       "   concepts {\n",
+       "     id: \"id-cat\"\n",
+       "     name: \"cat\"\n",
+       "     value: 1\n",
+       "     app_id: \"databricks_tester_img\"\n",
+       "   }\n",
+       " }\n",
+       " created_at {\n",
+       "   seconds: 1700217667\n",
+       "   nanos: 95690000\n",
+       " }\n",
+       " modified_at {\n",
+       "   seconds: 1700217668\n",
+       "   nanos: 751659000\n",
+       " }\n",
+       " status {\n",
+       "   code: INPUT_DOWNLOAD_SUCCESS\n",
+       "   description: \"Download complete\"\n",
+       " },\n",
+       " id: \"c8\"\n",
+       " data {\n",
+       "   image {\n",
+       "     url: \"https://data.clarifai.com/orig/users/mansi_k/apps/databricks_tester_img/inputs/image/1a56dcd4d97934cb2736c1ac3877e373\"\n",
+       "     hosted {\n",
+       "       prefix: \"https://data.clarifai.com\"\n",
+       "       suffix: \"users/mansi_k/apps/databricks_tester_img/inputs/image/1a56dcd4d97934cb2736c1ac3877e373\"\n",
+       "       sizes: \"orig\"\n",
+       "       sizes: \"tiny\"\n",
+       "       sizes: \"small\"\n",
+       "       sizes: \"large\"\n",
+       "       crossorigin: \"use-credentials\"\n",
+       "     }\n",
+       "     image_info {\n",
+       "       width: 930\n",
+       "       height: 620\n",
+       "       format: \"WebP\"\n",
+       "       color_mode: \"YUV\"\n",
+       "     }\n",
+       "   }\n",
+       "   concepts {\n",
+       "     id: \"id-cat\"\n",
+       "     name: \"cat\"\n",
+       "     value: 1\n",
+       "     app_id: \"databricks_tester_img\"\n",
+       "   }\n",
+       " }\n",
+       " created_at {\n",
+       "   seconds: 1700217667\n",
+       "   nanos: 95690000\n",
+       " }\n",
+       " modified_at {\n",
+       "   seconds: 1700217668\n",
+       "   nanos: 751659000\n",
+       " }\n",
+       " status {\n",
+       "   code: INPUT_DOWNLOAD_SUCCESS\n",
+       "   description: \"Download complete\"\n",
+       " },\n",
+       " id: \"c7\"\n",
+       " data {\n",
+       "   image {\n",
+       "     url: \"https://data.clarifai.com/orig/users/mansi_k/apps/databricks_tester_img/inputs/image/042dc758e67c807683d8f7cb3a064fd3\"\n",
+       "     hosted {\n",
+       "       prefix: \"https://data.clarifai.com\"\n",
+       "       suffix: \"users/mansi_k/apps/databricks_tester_img/inputs/image/042dc758e67c807683d8f7cb3a064fd3\"\n",
+       "       sizes: \"orig\"\n",
+       "       sizes: \"tiny\"\n",
+       "       sizes: \"small\"\n",
+       "       sizes: \"large\"\n",
+       "       crossorigin: \"use-credentials\"\n",
+       "     }\n",
+       "     image_info {\n",
+       "       width: 540\n",
+       "       height: 360\n",
+       "       format: \"JPEG\"\n",
+       "       color_mode: \"YUV\"\n",
+       "     }\n",
+       "   }\n",
+       "   concepts {\n",
+       "     id: \"id-cat\"\n",
+       "     name: \"cat\"\n",
+       "     value: 1\n",
+       "     app_id: \"databricks_tester_img\"\n",
+       "   }\n",
+       " }\n",
+       " created_at {\n",
+       "   seconds: 1700217667\n",
+       "   nanos: 95690000\n",
+       " }\n",
+       " modified_at {\n",
+       "   seconds: 1700217668\n",
+       "   nanos: 751659000\n",
+       " }\n",
+       " status {\n",
+       "   code: INPUT_DOWNLOAD_SUCCESS\n",
+       "   description: \"Download complete\"\n",
+       " },\n",
+       " id: \"c9\"\n",
+       " data {\n",
+       "   image {\n",
+       "     url: \"https://data.clarifai.com/orig/users/mansi_k/apps/databricks_tester_img/inputs/image/b88d83dd8fb9f34011ce441bd0cb823b\"\n",
+       "     hosted {\n",
+       "       prefix: \"https://data.clarifai.com\"\n",
+       "       suffix: \"users/mansi_k/apps/databricks_tester_img/inputs/image/b88d83dd8fb9f34011ce441bd0cb823b\"\n",
+       "       sizes: \"orig\"\n",
+       "       sizes: \"tiny\"\n",
+       "       sizes: \"small\"\n",
+       "       sizes: \"large\"\n",
+       "       crossorigin: \"use-credentials\"\n",
+       "     }\n",
+       "     image_info {\n",
+       "       width: 1200\n",
+       "       height: 834\n",
+       "       format: \"JPEG\"\n",
+       "       color_mode: \"YUV\"\n",
+       "     }\n",
+       "   }\n",
+       "   concepts {\n",
+       "     id: \"id-cat\"\n",
+       "     name: \"cat\"\n",
+       "     value: 1\n",
+       "     app_id: \"databricks_tester_img\"\n",
+       "   }\n",
+       " }\n",
+       " created_at {\n",
+       "   seconds: 1700217667\n",
+       "   nanos: 95690000\n",
+       " }\n",
+       " modified_at {\n",
+       "   seconds: 1700217668\n",
+       "   nanos: 751659000\n",
+       " }\n",
+       " status {\n",
+       "   code: INPUT_DOWNLOAD_SUCCESS\n",
+       "   description: \"Download complete\"\n",
+       " },\n",
+       " id: \"c4\"\n",
+       " data {\n",
+       "   image {\n",
+       "     url: \"https://data.clarifai.com/orig/users/mansi_k/apps/databricks_tester_img/inputs/image/55889a69788a8ff9a4aab1e457f7420f\"\n",
+       "     hosted {\n",
+       "       prefix: \"https://data.clarifai.com\"\n",
+       "       suffix: \"users/mansi_k/apps/databricks_tester_img/inputs/image/55889a69788a8ff9a4aab1e457f7420f\"\n",
+       "       sizes: \"orig\"\n",
+       "       sizes: \"tiny\"\n",
+       "       sizes: \"small\"\n",
+       "       sizes: \"large\"\n",
+       "       crossorigin: \"use-credentials\"\n",
+       "     }\n",
+       "     image_info {\n",
+       "       width: 1600\n",
+       "       height: 1435\n",
+       "       format: \"WebP\"\n",
+       "       color_mode: \"YUV\"\n",
+       "     }\n",
+       "   }\n",
+       "   concepts {\n",
+       "     id: \"id-cat\"\n",
+       "     name: \"cat\"\n",
+       "     value: 1\n",
+       "     app_id: \"databricks_tester_img\"\n",
+       "   }\n",
+       " }\n",
+       " created_at {\n",
+       "   seconds: 1700217667\n",
+       "   nanos: 95690000\n",
+       " }\n",
+       " modified_at {\n",
+       "   seconds: 1700217668\n",
+       "   nanos: 751659000\n",
+       " }\n",
+       " status {\n",
+       "   code: INPUT_DOWNLOAD_SUCCESS\n",
+       "   description: \"Download complete\"\n",
+       " },\n",
+       " id: \"c5\"\n",
+       " data {\n",
+       "   image {\n",
+       "     url: \"https://data.clarifai.com/orig/users/mansi_k/apps/databricks_tester_img/inputs/image/e91483b17642cc4540cfb97afad3196b\"\n",
+       "     hosted {\n",
+       "       prefix: \"https://data.clarifai.com\"\n",
+       "       suffix: \"users/mansi_k/apps/databricks_tester_img/inputs/image/e91483b17642cc4540cfb97afad3196b\"\n",
+       "       sizes: \"orig\"\n",
+       "       sizes: \"tiny\"\n",
+       "       sizes: \"small\"\n",
+       "       sizes: \"large\"\n",
+       "       crossorigin: \"use-credentials\"\n",
+       "     }\n",
+       "     image_info {\n",
+       "       width: 500\n",
+       "       height: 473\n",
+       "       format: \"JPEG\"\n",
+       "       color_mode: \"YUV\"\n",
+       "     }\n",
+       "   }\n",
+       "   concepts {\n",
+       "     id: \"id-cat\"\n",
+       "     name: \"cat\"\n",
+       "     value: 1\n",
+       "     app_id: \"databricks_tester_img\"\n",
+       "   }\n",
+       " }\n",
+       " created_at {\n",
+       "   seconds: 1700217667\n",
+       "   nanos: 95690000\n",
+       " }\n",
+       " modified_at {\n",
+       "   seconds: 1700217668\n",
+       "   nanos: 751659000\n",
+       " }\n",
+       " status {\n",
+       "   code: INPUT_DOWNLOAD_SUCCESS\n",
+       "   description: \"Download complete\"\n",
+       " },\n",
+       " id: \"c10\"\n",
        " data {\n",
        "   image {\n",
        "     url: \"https://data.clarifai.com/orig/users/mansi_k/apps/databricks_tester_img/inputs/image/c1b5a9392f89cf42deca348758a63c79\"\n",
@@ -197,7 +766,7 @@
        "   concepts {\n",
        "     id: \"id-cat\"\n",
        "     name: \"cat\"\n",
-       "     value: 1.0\n",
+       "     value: 1\n",
        "     app_id: \"databricks_tester_img\"\n",
        "   }\n",
        " }\n",
@@ -236,7 +805,7 @@
        "   concepts {\n",
        "     id: \"id-cat\"\n",
        "     name: \"cat\"\n",
-       "     value: 1.0\n",
+       "     value: 1\n",
        "     app_id: \"databricks_tester_img\"\n",
        "   }\n",
        " }\n",
@@ -275,7 +844,7 @@
        "   concepts {\n",
        "     id: \"id-cat\"\n",
        "     name: \"cat\"\n",
-       "     value: 1.0\n",
+       "     value: 1\n",
        "     app_id: \"databricks_tester_img\"\n",
        "   }\n",
        " }\n",
@@ -314,7 +883,7 @@
        "   concepts {\n",
        "     id: \"id-cat\"\n",
        "     name: \"cat\"\n",
-       "     value: 1.0\n",
+       "     value: 1\n",
        "     app_id: \"databricks_tester_img\"\n",
        "   }\n",
        " }\n",
@@ -353,7 +922,7 @@
        "   concepts {\n",
        "     id: \"id-cat\"\n",
        "     name: \"cat\"\n",
-       "     value: 1.0\n",
+       "     value: 1\n",
        "     app_id: \"databricks_tester_img\"\n",
        "   }\n",
        " }\n",
@@ -371,7 +940,7 @@
        " }]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -385,63 +954,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
-     "inputWidgets": {},
-     "nuid": "76a4ffe7-3a47-42ad-84db-1126aacd9cb1",
-     "showTitle": false,
-     "title": ""
-    }
-   },
-   "source": [
-    "### Upload images from volume folder to Clarifai dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "inputWidgets": {},
-     "nuid": "d15b3001-8b49-498b-b7c3-60d775047671",
-     "showTitle": false,
-     "title": ""
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-10-23 08:27:37 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m2023-10-23 08:27:37\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=55296;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=786623;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\rUploading inputs:   0%|          | 0/1 [00:00<?, ?it/s]\rUploading inputs: 100%|██████████| 1/1 [00:05<00:00,  5.36s/it]\rUploading inputs: 100%|██████████| 1/1 [00:05<00:00,  5.36s/it]\n"
-     ]
-    }
-   ],
-   "source": [
-    "dataset_obj.upload_dataset_from_folder(folder_path='/Volumes/mansi_test/default/cat', input_type='image', labels=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "522a228a-52dd-417e-b02c-fa896e7833ad",
      "showTitle": false,
@@ -471,11 +987,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-11-17 10:42:14 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-12-15 09:36:07 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m2023-11-17 10:42:14\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=867812;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=60747;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001b[2;36m2023-12-15 09:36:07\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=445298;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=139856;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
       ]
      },
      "metadata": {},
@@ -487,7 +1003,7 @@
        "DataFrame[annotation: string, annotation_created_at: string, annotation_id: string, annotation_modified_at: string, annotation_user_id: string, input_id: string]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -501,7 +1017,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "228872b2-c1d2-4058-a92c-f81b23d48b47",
      "showTitle": false,
@@ -531,11 +1050,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-11-17 10:43:04 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-12-15 09:36:18 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m2023-11-17 10:43:04\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=804695;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=346850;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001b[2;36m2023-12-15 09:36:18\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=669970;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=978259;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
       ]
      },
      "metadata": {},
@@ -543,14 +1062,17 @@
     }
    ],
    "source": [
-    "annot_df.write.format(\"delta\").mode(\"overwrite\").save(\"/Volumes/mansi_test/default/test_vol1/imgAnnsDeltaTable2\")\n"
+    "annot_df.write.mode(\"overwrite\").saveAsTable(\"mansi_test.default.imgAnnsDeltaTable\")\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "d938ddb1-ae12-44df-92b2-cceeb19b24e7",
      "showTitle": false,
@@ -580,11 +1102,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-11-17 10:45:04 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-12-15 09:37:26 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m2023-11-17 10:45:04\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=912153;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=905134;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001b[2;36m2023-12-15 09:37:26\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=299959;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=970950;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
       ]
      },
      "metadata": {},
@@ -594,21 +1116,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "+--------------------+---------------------+--------------------+----------------------+------------------+--------+\n",
-      "|          annotation|annotation_created_at|       annotation_id|annotation_modified_at|annotation_user_id|input_id|\n",
-      "+--------------------+---------------------+--------------------+----------------------+------------------+--------+\n",
-      "|concepts {\\n  id:...|  10/23/% 08:27:   %5|b3847d13486f4f118...|   10/23/% 08:27:   %5|           mansi_k|      c2|\n",
-      "|concepts {\\n  id:...|  10/23/% 08:27:   %5|f65d75b3446b40ffa...|   10/23/% 08:27:   %5|           mansi_k|     c11|\n",
-      "|concepts {\\n  id:...|  11/17/% 10:41:   %5|76ac2fcb998440bc8...|   11/17/% 10:41:   %5|           mansi_k|      c8|\n",
-      "|concepts {\\n  id:...|  11/17/% 10:41:   %5|7edf0bc509454a9ca...|   11/17/% 10:41:   %5|           mansi_k|      c4|\n",
-      "|concepts {\\n  id:...|  10/23/% 08:27:   %5|8fd99dc05eef46849...|   10/23/% 08:27:   %5|           mansi_k|      c1|\n",
-      "|concepts {\\n  id:...|  11/17/% 10:41:   %5|f044bc745f754544b...|   11/17/% 10:41:   %5|           mansi_k|      c7|\n",
-      "|concepts {\\n  id:...|  10/23/% 08:27:   %5|0a28d0a6b7a04234b...|   10/23/% 08:27:   %5|           mansi_k|     c10|\n",
-      "|concepts {\\n  id:...|  10/23/% 08:27:   %5|4ec53920e7e34e569...|   10/23/% 08:27:   %5|           mansi_k|      c3|\n",
-      "|concepts {\\n  id:...|  11/17/% 10:41:   %5|63b054c8fd754b698...|   11/17/% 10:41:   %5|           mansi_k|      c6|\n",
-      "|concepts {\\n  id:...|  11/17/% 10:41:   %5|170d036a60544e789...|   11/17/% 10:41:   %5|           mansi_k|      c9|\n",
-      "|concepts {\\n  id:...|  11/17/% 10:41:   %5|a759f8a2d0a248b2b...|   11/17/% 10:41:   %5|           mansi_k|      c5|\n",
-      "+--------------------+---------------------+--------------------+----------------------+------------------+--------+\n",
+      "+--------------------+---------------------+--------------------+----------------------+------------------+--------------------+\n",
+      "|          annotation|annotation_created_at|       annotation_id|annotation_modified_at|annotation_user_id|            input_id|\n",
+      "+--------------------+---------------------+--------------------+----------------------+------------------+--------------------+\n",
+      "|concepts {\\n  id:...|  11/17/% 10:48:   %5|ed88ef462bfc420cb...|   11/17/% 10:48:   %5|           mansi_k|dataset1-train-33...|\n",
+      "|concepts {\\n  id:...|  11/17/% 10:48:   %5|8a548049732840edb...|   11/17/% 10:48:   %5|           mansi_k|               img21|\n",
+      "|concepts {\\n  id:...|  11/17/% 10:48:   %5|99e1544ff42a4695a...|   11/17/% 10:48:   %5|           mansi_k|               img11|\n",
+      "|concepts {\\n  id:...|  11/17/% 10:41:   %5|170d036a60544e789...|   11/17/% 10:41:   %5|           mansi_k|                  c9|\n",
+      "|concepts {\\n  id:...|  11/17/% 10:41:   %5|7edf0bc509454a9ca...|   11/17/% 10:41:   %5|           mansi_k|                  c4|\n",
+      "|concepts {\\n  id:...|  11/17/% 10:41:   %5|a759f8a2d0a248b2b...|   11/17/% 10:41:   %5|           mansi_k|                  c5|\n",
+      "|concepts {\\n  id:...|  11/17/% 10:41:   %5|f044bc745f754544b...|   11/17/% 10:41:   %5|           mansi_k|                  c7|\n",
+      "|concepts {\\n  id:...|  10/23/% 08:27:   %5|0a28d0a6b7a04234b...|   10/23/% 08:27:   %5|           mansi_k|                 c10|\n",
+      "|concepts {\\n  id:...|  11/17/% 10:48:   %5|8d1809e5078d40579...|   11/17/% 10:48:   %5|           mansi_k|dataset1-train-35...|\n",
+      "|concepts {\\n  id:...|  11/17/% 10:48:   %5|8e246698055843cfa...|   11/17/% 10:48:   %5|           mansi_k|dataset1-train-24...|\n",
+      "+--------------------+---------------------+--------------------+----------------------+------------------+--------------------+\n",
+      "only showing top 10 rows\n",
       "\n"
      ]
     }
@@ -616,8 +1138,8 @@
    "source": [
     "spark = SparkSession.builder.appName(\"Clarifai-pyspark\").getOrCreate()\n",
     "spark.conf.set(\"spark.databricks.agent.id\", \"clarifai-pyspark\")\n",
-    "df_delta = spark.read.format(\"delta\").load(\"/Volumes/mansi_test/default/test_vol1/imgAnnsDeltaTable2\")\n",
-    "df_delta.show()"
+    "df_delta = spark.read.table(\"mansi_test.default.imgAnnsDeltaTable\")\n",
+    "df_delta.show(10)"
    ]
   },
   {
@@ -799,7 +1321,7 @@
     }
    },
    "source": [
-    "### Load image csv file & upload text data into app using dataframe"
+    "### Load image csv file & upload image data into app using dataframe"
    ]
   },
   {
@@ -900,6 +1422,101 @@
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
      "inputWidgets": {},
+     "nuid": "1db3300b-3940-497d-be2c-2268314b6308",
+     "showTitle": false,
+     "title": ""
+    }
+   },
+   "source": [
+    "### Upload images from a delta table to Clarifai app"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "03d929fe-d943-4e32-917d-aae28430c6e4",
+     "showTitle": false,
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\rUploading inputs:   0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-12-11 17:47:48 </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING </span> clarifai.client.input:  code: IN<span style=\"color: #808000; text-decoration-color: #808000; font-weight: bold\">PUT</span>_DUPLICATE                             <a href=\"file:///local_disk0/.ephemeral_nfs/envs/pythonEnv-c207ed42-01ac-4f0a-b762-3bca3452a74d/lib/python3.10/site-packages/clarifai/client/input.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">input.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///local_disk0/.ephemeral_nfs/envs/pythonEnv-c207ed42-01ac-4f0a-b762-3bca3452a74d/lib/python3.10/site-packages/clarifai/client/input.py#662\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">662</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         description: <span style=\"color: #008000; text-decoration-color: #008000\">\"Duplicate URL in your application. Check the documentation </span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">            </span>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         <span style=\"color: #008000; text-decoration-color: #008000\">to allow duplications.\"</span>                                                   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">            </span>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         details: <span style=\"color: #008000; text-decoration-color: #008000\">\"The input URL is duplicate.\"</span>                                    <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">            </span>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>                                                                                   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">            </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m2023-12-11 17:47:48\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING \u001b[0m clarifai.client.input:  code: IN\u001b[1;33mPUT\u001b[0m_DUPLICATE                             \u001b]8;id=345352;file:///local_disk0/.ephemeral_nfs/envs/pythonEnv-c207ed42-01ac-4f0a-b762-3bca3452a74d/lib/python3.10/site-packages/clarifai/client/input.py\u001b\\\u001b[2minput.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=764534;file:///local_disk0/.ephemeral_nfs/envs/pythonEnv-c207ed42-01ac-4f0a-b762-3bca3452a74d/lib/python3.10/site-packages/clarifai/client/input.py#662\u001b\\\u001b[2m662\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[2;36m                    \u001b[0m         description: \u001b[32m\"Duplicate URL in your application. Check the documentation \u001b[0m \u001b[2m            \u001b[0m\n",
+       "\u001b[2;36m                    \u001b[0m         \u001b[32mto allow duplications.\"\u001b[0m                                                   \u001b[2m            \u001b[0m\n",
+       "\u001b[2;36m                    \u001b[0m         details: \u001b[32m\"The input URL is duplicate.\"\u001b[0m                                    \u001b[2m            \u001b[0m\n",
+       "\u001b[2;36m                    \u001b[0m                                                                                   \u001b[2m            \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-12-11 17:47:48 </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING </span> clarifai.client.input:  code: IN<span style=\"color: #808000; text-decoration-color: #808000; font-weight: bold\">PUT</span>_DUPLICATE                             <a href=\"file:///local_disk0/.ephemeral_nfs/envs/pythonEnv-c207ed42-01ac-4f0a-b762-3bca3452a74d/lib/python3.10/site-packages/clarifai/client/input.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">input.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///local_disk0/.ephemeral_nfs/envs/pythonEnv-c207ed42-01ac-4f0a-b762-3bca3452a74d/lib/python3.10/site-packages/clarifai/client/input.py#662\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">662</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         description: <span style=\"color: #008000; text-decoration-color: #008000\">\"Duplicate URL in your application. Check the documentation </span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">            </span>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         <span style=\"color: #008000; text-decoration-color: #008000\">to allow duplications.\"</span>                                                   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">            </span>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         details: <span style=\"color: #008000; text-decoration-color: #008000\">\"The input URL is duplicate.\"</span>                                    <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">            </span>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>                                                                                   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">            </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m2023-12-11 17:47:48\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING \u001b[0m clarifai.client.input:  code: IN\u001b[1;33mPUT\u001b[0m_DUPLICATE                             \u001b]8;id=392716;file:///local_disk0/.ephemeral_nfs/envs/pythonEnv-c207ed42-01ac-4f0a-b762-3bca3452a74d/lib/python3.10/site-packages/clarifai/client/input.py\u001b\\\u001b[2minput.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=422922;file:///local_disk0/.ephemeral_nfs/envs/pythonEnv-c207ed42-01ac-4f0a-b762-3bca3452a74d/lib/python3.10/site-packages/clarifai/client/input.py#662\u001b\\\u001b[2m662\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[2;36m                    \u001b[0m         description: \u001b[32m\"Duplicate URL in your application. Check the documentation \u001b[0m \u001b[2m            \u001b[0m\n",
+       "\u001b[2;36m                    \u001b[0m         \u001b[32mto allow duplications.\"\u001b[0m                                                   \u001b[2m            \u001b[0m\n",
+       "\u001b[2;36m                    \u001b[0m         details: \u001b[32m\"The input URL is duplicate.\"\u001b[0m                                    \u001b[2m            \u001b[0m\n",
+       "\u001b[2;36m                    \u001b[0m                                                                                   \u001b[2m            \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\rUploading inputs: 100%|██████████| 1/1 [00:02<00:00,  2.71s/it]\rUploading inputs: 100%|██████████| 1/1 [00:02<00:00,  2.71s/it]\n"
+     ]
+    }
+   ],
+   "source": [
+    "dataset_obj.upload_dataset_from_table(table_path=\"/Volumes/mansi_test/default/test_vol1/imgdeltatable1\", \n",
+    "                                      input_type=\"image\",\n",
+    "                                      table_type=\"url\",\n",
+    "                                      labels=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
      "nuid": "a1382140-4c49-4bbf-9e0c-9fcd860071e5",
      "showTitle": false,
      "title": ""
@@ -912,7 +1529,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "4c550131-e182-446f-a6b6-b7e11c38826c",
+     "showTitle": false,
+     "title": ""
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -974,15 +1599,28 @@
    },
    "outputs": [
     {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-12-15 08:19:00 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m2023-12-15 08:19:00\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=117498;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=437332;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\rExporting Images:   0%|          | 0/18 [00:00<?, ?it/s]\rExporting Images:   6%|▌         | 1/18 [00:02<00:36,  2.17s/it]\rExporting Images:  33%|███▎      | 6/18 [00:03<00:05,  2.12it/s]\rExporting Images:  39%|███▉      | 7/18 [00:03<00:04,  2.50it/s]\rExporting Images:  56%|█████▌    | 10/18 [00:03<00:02,  3.97it/s]\rExporting Images:  67%|██████▋   | 12/18 [00:03<00:01,  4.95it/s]\rExporting Images:  72%|███████▏  | 13/18 [00:04<00:01,  3.50it/s]\rExporting Images:  78%|███████▊  | 14/18 [00:04<00:01,  3.52it/s]\rExporting Images:  89%|████████▉ | 16/18 [00:04<00:00,  5.03it/s]\rExporting Images: 100%|██████████| 18/18 [00:05<00:00,  6.43it/s]\rExporting Images: 100%|██████████| 18/18 [00:05<00:00,  3.55it/s]\n"
+      "\rExporting Images:   0%|          | 0/20 [00:00<?, ?it/s]\rExporting Images:   5%|▌         | 1/20 [00:01<00:32,  1.71s/it]\rExporting Images:  20%|██        | 4/20 [00:01<00:05,  2.84it/s]\rExporting Images:  30%|███       | 6/20 [00:02<00:04,  3.15it/s]\rExporting Images:  40%|████      | 8/20 [00:03<00:03,  3.10it/s]\rExporting Images:  45%|████▌     | 9/20 [00:03<00:03,  3.31it/s]\rExporting Images:  55%|█████▌    | 11/20 [00:03<00:02,  4.03it/s]\rExporting Images:  65%|██████▌   | 13/20 [00:03<00:01,  5.47it/s]\rExporting Images:  80%|████████  | 16/20 [00:04<00:00,  4.65it/s]\rExporting Images:  85%|████████▌ | 17/20 [00:04<00:00,  4.62it/s]\rExporting Images:  95%|█████████▌| 19/20 [00:04<00:00,  5.55it/s]\rExporting Images: 100%|██████████| 20/20 [00:04<00:00,  4.08it/s]\n"
      ]
     }
    ],
    "source": [
-    "dataset_obj.export_annotations_to_volume(volumepath=\"/Volumes/mansi_test/default/test_vol2\",)"
+    "dataset_obj.export_annotations_to_volume(volumepath=\"/Volumes/mansi_test/default/test_vol4\",)"
    ]
   },
   {
@@ -1002,16 +1640,29 @@
    },
    "outputs": [
     {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-12-15 08:22:46 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m2023-12-15 08:22:46\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=334353;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=684348;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "+--------------------+---------------------+--------------------+----------------------+------------------+--------------------+--------------------+\n",
       "|          annotation|annotation_created_at|       annotation_id|annotation_modified_at|annotation_user_id|           image_url|            input_id|\n",
       "+--------------------+---------------------+--------------------+----------------------+------------------+--------------------+--------------------+\n",
-      "|regions {\\n  id: ...|  11/20/% 08:43:   %5|    WqbneIj80QXf5Xd2|   11/20/% 08:43:   %5|           mansi_k|https://img.freep...|               img11|\n",
-      "|concepts {\\n  id:...|  11/17/% 10:48:   %5|406a50cae84541b2b...|   11/17/% 10:48:   %5|           mansi_k|https://data.clar...|dataset1-train-36...|\n",
-      "|concepts {\\n  id:...|  11/17/% 10:41:   %5|63b054c8fd754b698...|   11/17/% 10:41:   %5|           mansi_k|https://data.clar...|                  c6|\n",
-      "|concepts {\\n  id:...|  11/17/% 10:41:   %5|76ac2fcb998440bc8...|   11/17/% 10:41:   %5|           mansi_k|https://data.clar...|                  c8|\n",
+      "|concepts {\\n  id:...|  11/17/% 10:48:   %5|8d1809e5078d40579...|   11/17/% 10:48:   %5|           mansi_k|https://data.clar...|dataset1-train-35...|\n",
+      "|concepts {\\n  id:...|  11/17/% 10:48:   %5|8e246698055843cfa...|   11/17/% 10:48:   %5|           mansi_k|https://data.clar...|dataset1-train-24...|\n",
+      "|concepts {\\n  id:...|  11/17/% 10:41:   %5|f044bc745f754544b...|   11/17/% 10:41:   %5|           mansi_k|https://data.clar...|                  c7|\n",
+      "|concepts {\\n  id:...|  10/23/% 08:27:   %5|0a28d0a6b7a04234b...|   10/23/% 08:27:   %5|           mansi_k|https://data.clar...|                 c10|\n",
       "+--------------------+---------------------+--------------------+----------------------+------------------+--------------------+--------------------+\n",
       "only showing top 4 rows\n",
       "\n"
@@ -1019,7 +1670,7 @@
     }
    ],
    "source": [
-    "df_delta = spark.read.format(\"delta\").load(\"/Volumes/mansi_test/default/test_vol2\")\n",
+    "df_delta = spark.read.format(\"delta\").load(\"/Volumes/mansi_test/default/test_vol4\")\n",
     "df_delta.show(4)"
    ]
   },

--- a/examples/delta_live_table_upsert_demo.ipynb
+++ b/examples/delta_live_table_upsert_demo.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -111,35 +111,25 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-11-17 16:11:15 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m2023-11-17 16:11:15\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=884448;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=122031;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001B[2;36m2023-11-17 16:11:15\u001B[0m\u001B[2;36m \u001B[0m\u001B[34mINFO    \u001B[0m INFO:py4j.clientserver:Received command c on object id p0          \u001B]8;id=884448;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001B\\\u001B[2mclientserver.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=122031;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001B\\\u001B[2m575\u001B[0m\u001B]8;;\u001B\\\n"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
     },
     {
+     "output_type": "stream",
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "+--------------------+---------------------+--------------------+----------------------+------------------+----------------+\n",
-      "|          annotation|annotation_created_at|       annotation_id|annotation_modified_at|annotation_user_id|        input_id|\n",
-      "+--------------------+---------------------+--------------------+----------------------+------------------+----------------+\n",
-      "|text {\\n  url: \"h...|  10/30/% 15:04:   %5|f602439fd7b14aa6b...|   10/30/% 15:04:   %5|           mansi_k|XFmGD0xHlNXgGIXF|\n",
-      "|concepts {\\n  id:...|  10/30/% 13:02:   %5|    TVFLGTHd8NryFWsY|   10/30/% 13:02:   %5|           mansi_k|Ak1n8DZ1l1RWKATv|\n",
-      "|text {\\n  url: \"h...|  10/30/% 12:46:   %5|125b80fb08604e36a...|   10/30/% 12:46:   %5|           mansi_k|Ak1n8DZ1l1RWKATv|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:45:   %5|190e2387564c416f8...|   10/26/% 12:45:   %5|           mansi_k|PKaXcNjJ5fJ7wZqR|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:45:   %5|22757a0e73fa4cac8...|   10/26/% 12:45:   %5|           mansi_k|IYMxwJq0jjwJguLE|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:43:   %5|    NrOaWbbfH6QEVFBW|   10/26/% 12:43:   %5|           mansi_k|             t11|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:43:   %5|    8sH9gt43eqx3rBYF|   10/26/% 12:43:   %5|           mansi_k|             t21|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:43:   %5|    fc9VQUXheCJaZu28|   10/26/% 12:43:   %5|           mansi_k|             t31|\n",
-      "+--------------------+---------------------+--------------------+----------------------+------------------+----------------+\n",
-      "\n"
+      "+--------------------+---------------------+--------------------+----------------------+------------------+----------------+\n|          annotation|annotation_created_at|       annotation_id|annotation_modified_at|annotation_user_id|        input_id|\n+--------------------+---------------------+--------------------+----------------------+------------------+----------------+\n|text {\\n  url: \"h...|  10/30/% 15:04:   %5|f602439fd7b14aa6b...|   10/30/% 15:04:   %5|           mansi_k|XFmGD0xHlNXgGIXF|\n|concepts {\\n  id:...|  10/30/% 13:02:   %5|    TVFLGTHd8NryFWsY|   10/30/% 13:02:   %5|           mansi_k|Ak1n8DZ1l1RWKATv|\n|text {\\n  url: \"h...|  10/30/% 12:46:   %5|125b80fb08604e36a...|   10/30/% 12:46:   %5|           mansi_k|Ak1n8DZ1l1RWKATv|\n|concepts {\\n  id:...|  10/26/% 12:45:   %5|190e2387564c416f8...|   10/26/% 12:45:   %5|           mansi_k|PKaXcNjJ5fJ7wZqR|\n|concepts {\\n  id:...|  10/26/% 12:45:   %5|22757a0e73fa4cac8...|   10/26/% 12:45:   %5|           mansi_k|IYMxwJq0jjwJguLE|\n|concepts {\\n  id:...|  10/26/% 12:43:   %5|    NrOaWbbfH6QEVFBW|   10/26/% 12:43:   %5|           mansi_k|             t11|\n|concepts {\\n  id:...|  10/26/% 12:43:   %5|    8sH9gt43eqx3rBYF|   10/26/% 12:43:   %5|           mansi_k|             t21|\n|concepts {\\n  id:...|  10/26/% 12:43:   %5|    fc9VQUXheCJaZu28|   10/26/% 12:43:   %5|           mansi_k|             t31|\n+--------------------+---------------------+--------------------+----------------------+------------------+----------------+\n\n"
      ]
     }
    ],
@@ -165,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -180,19 +170,21 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-11-17 16:11:55 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m2023-11-17 16:11:55\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=80314;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=963085;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001B[2;36m2023-11-17 16:11:55\u001B[0m\u001B[2;36m \u001B[0m\u001B[34mINFO    \u001B[0m INFO:py4j.clientserver:Received command c on object id p0          \u001B]8;id=80314;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001B\\\u001B[2mclientserver.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=963085;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001B\\\u001B[2m575\u001B[0m\u001B]8;;\u001B\\\n"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
     },
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "DataFrame[]"
@@ -212,8 +204,8 @@
     "spark.conf.set(\"spark.databricks.agent.id\", \"clarifai-pyspark\")\n",
     "database_name = \"db_test\"\n",
     "table_name = \"dlt_anns2\"\n",
-    "delta_path = \"/mnt/delta_anns2\"\n",
-    "annot_df.write.format(\"delta\").mode(\"overwrite\").save(delta_path)\n",
+    "delta_path = \"mansi_test.default.delta_anns_table2\"\n",
+    "annot_df.write.mode(\"overwrite\").saveAsTable(delta_path)\n",
     "\n",
     "# Create a Spark session\n",
     "spark.sql(f\"CREATE DATABASE IF NOT EXISTS {database_name}\")\n",
@@ -242,7 +234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -257,40 +249,30 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-11-17 16:12:43 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m2023-11-17 16:12:43\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=60690;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=866565;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001B[2;36m2023-11-17 16:12:43\u001B[0m\u001B[2;36m \u001B[0m\u001B[34mINFO    \u001B[0m INFO:py4j.clientserver:Received command c on object id p0          \u001B]8;id=60690;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001B\\\u001B[2mclientserver.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=866565;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001B\\\u001B[2m575\u001B[0m\u001B]8;;\u001B\\\n"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
     },
     {
+     "output_type": "stream",
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "+--------------------+---------------------+--------------------+----------------------+------------------+----------------+\n",
-      "|          annotation|annotation_created_at|       annotation_id|annotation_modified_at|annotation_user_id|        input_id|\n",
-      "+--------------------+---------------------+--------------------+----------------------+------------------+----------------+\n",
-      "|concepts {\\n  id:...|  10/26/% 12:45:   %5|22757a0e73fa4cac8...|   10/26/% 12:45:   %5|           mansi_k|IYMxwJq0jjwJguLE|\n",
-      "|text {\\n  url: \"h...|  10/30/% 12:46:   %5|125b80fb08604e36a...|   10/30/% 12:46:   %5|           mansi_k|Ak1n8DZ1l1RWKATv|\n",
-      "|text {\\n  url: \"h...|  10/30/% 15:04:   %5|f602439fd7b14aa6b...|   10/30/% 15:04:   %5|           mansi_k|XFmGD0xHlNXgGIXF|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:43:   %5|    8sH9gt43eqx3rBYF|   10/26/% 12:43:   %5|           mansi_k|             t21|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:45:   %5|190e2387564c416f8...|   10/26/% 12:45:   %5|           mansi_k|PKaXcNjJ5fJ7wZqR|\n",
-      "|concepts {\\n  id:...|  10/30/% 13:02:   %5|    TVFLGTHd8NryFWsY|   10/30/% 13:02:   %5|           mansi_k|Ak1n8DZ1l1RWKATv|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:43:   %5|    NrOaWbbfH6QEVFBW|   10/26/% 12:43:   %5|           mansi_k|             t11|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:43:   %5|    fc9VQUXheCJaZu28|   10/26/% 12:43:   %5|           mansi_k|             t31|\n",
-      "+--------------------+---------------------+--------------------+----------------------+------------------+----------------+\n",
-      "\n"
+      "+--------------------+---------------------+--------------------+----------------------+------------------+----------------+\n|          annotation|annotation_created_at|       annotation_id|annotation_modified_at|annotation_user_id|        input_id|\n+--------------------+---------------------+--------------------+----------------------+------------------+----------------+\n|concepts {\\n  id:...|  10/26/% 12:45:   %5|22757a0e73fa4cac8...|   10/26/% 12:45:   %5|           mansi_k|IYMxwJq0jjwJguLE|\n|text {\\n  url: \"h...|  10/30/% 12:46:   %5|125b80fb08604e36a...|   10/30/% 12:46:   %5|           mansi_k|Ak1n8DZ1l1RWKATv|\n|text {\\n  url: \"h...|  10/30/% 15:04:   %5|f602439fd7b14aa6b...|   10/30/% 15:04:   %5|           mansi_k|XFmGD0xHlNXgGIXF|\n|concepts {\\n  id:...|  10/26/% 12:43:   %5|    8sH9gt43eqx3rBYF|   10/26/% 12:43:   %5|           mansi_k|             t21|\n|concepts {\\n  id:...|  10/26/% 12:45:   %5|190e2387564c416f8...|   10/26/% 12:45:   %5|           mansi_k|PKaXcNjJ5fJ7wZqR|\n|concepts {\\n  id:...|  10/30/% 13:02:   %5|    TVFLGTHd8NryFWsY|   10/30/% 13:02:   %5|           mansi_k|Ak1n8DZ1l1RWKATv|\n|concepts {\\n  id:...|  10/26/% 12:43:   %5|    NrOaWbbfH6QEVFBW|   10/26/% 12:43:   %5|           mansi_k|             t11|\n|concepts {\\n  id:...|  10/26/% 12:43:   %5|    fc9VQUXheCJaZu28|   10/26/% 12:43:   %5|           mansi_k|             t31|\n+--------------------+---------------------+--------------------+----------------------+------------------+----------------+\n\n"
      ]
     }
    ],
    "source": [
-    "df_delta = spark.read.format(\"delta\").load(delta_path)\n",
+    "df_delta = spark.read.table(delta_path)\n",
     "df_delta.show()"
    ]
   },
@@ -311,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -343,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -358,37 +340,25 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-11-17 16:16:29 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m2023-11-17 16:16:29\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=802427;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=726084;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001B[2;36m2023-11-17 16:16:29\u001B[0m\u001B[2;36m \u001B[0m\u001B[34mINFO    \u001B[0m INFO:py4j.clientserver:Received command c on object id p0          \u001B]8;id=802427;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001B\\\u001B[2mclientserver.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=726084;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001B\\\u001B[2m575\u001B[0m\u001B]8;;\u001B\\\n"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
     },
     {
+     "output_type": "stream",
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "+--------------------+---------------------+--------------------+----------------------+------------------+--------------------+\n",
-      "|          annotation|annotation_created_at|       annotation_id|annotation_modified_at|annotation_user_id|            input_id|\n",
-      "+--------------------+---------------------+--------------------+----------------------+------------------+--------------------+\n",
-      "|concepts {\\n  id:...|  11/17/% 13:51:   %5|d0bb5fea2d8c4f4e8...|   11/17/% 13:51:   %5|           mansi_k|fe3f42364969fe544...|\n",
-      "|concepts {\\n  id:...|  11/17/% 13:43:   %5|1e6224252c324b04b...|   11/17/% 13:43:   %5|           mansi_k|5a1d54db53403352f...|\n",
-      "|text {\\n  url: \"h...|  10/30/% 15:04:   %5|f602439fd7b14aa6b...|   10/30/% 15:04:   %5|           mansi_k|    XFmGD0xHlNXgGIXF|\n",
-      "|concepts {\\n  id:...|  10/30/% 13:02:   %5|    TVFLGTHd8NryFWsY|   10/30/% 13:02:   %5|           mansi_k|    Ak1n8DZ1l1RWKATv|\n",
-      "|text {\\n  url: \"h...|  10/30/% 12:46:   %5|125b80fb08604e36a...|   10/30/% 12:46:   %5|           mansi_k|    Ak1n8DZ1l1RWKATv|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:45:   %5|190e2387564c416f8...|   10/26/% 12:45:   %5|           mansi_k|    PKaXcNjJ5fJ7wZqR|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:45:   %5|22757a0e73fa4cac8...|   10/26/% 12:45:   %5|           mansi_k|    IYMxwJq0jjwJguLE|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:43:   %5|    NrOaWbbfH6QEVFBW|   10/26/% 12:43:   %5|           mansi_k|                 t11|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:43:   %5|    8sH9gt43eqx3rBYF|   10/26/% 12:43:   %5|           mansi_k|                 t21|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:43:   %5|    fc9VQUXheCJaZu28|   10/26/% 12:43:   %5|           mansi_k|                 t31|\n",
-      "+--------------------+---------------------+--------------------+----------------------+------------------+--------------------+\n",
-      "\n"
+      "+--------------------+---------------------+--------------------+----------------------+------------------+--------------------+\n|          annotation|annotation_created_at|       annotation_id|annotation_modified_at|annotation_user_id|            input_id|\n+--------------------+---------------------+--------------------+----------------------+------------------+--------------------+\n|concepts {\\n  id:...|  11/17/% 13:51:   %5|d0bb5fea2d8c4f4e8...|   11/17/% 13:51:   %5|           mansi_k|fe3f42364969fe544...|\n|concepts {\\n  id:...|  11/17/% 13:43:   %5|1e6224252c324b04b...|   11/17/% 13:43:   %5|           mansi_k|5a1d54db53403352f...|\n|text {\\n  url: \"h...|  10/30/% 15:04:   %5|f602439fd7b14aa6b...|   10/30/% 15:04:   %5|           mansi_k|    XFmGD0xHlNXgGIXF|\n|concepts {\\n  id:...|  10/30/% 13:02:   %5|    TVFLGTHd8NryFWsY|   10/30/% 13:02:   %5|           mansi_k|    Ak1n8DZ1l1RWKATv|\n|text {\\n  url: \"h...|  10/30/% 12:46:   %5|125b80fb08604e36a...|   10/30/% 12:46:   %5|           mansi_k|    Ak1n8DZ1l1RWKATv|\n|concepts {\\n  id:...|  10/26/% 12:45:   %5|190e2387564c416f8...|   10/26/% 12:45:   %5|           mansi_k|    PKaXcNjJ5fJ7wZqR|\n|concepts {\\n  id:...|  10/26/% 12:45:   %5|22757a0e73fa4cac8...|   10/26/% 12:45:   %5|           mansi_k|    IYMxwJq0jjwJguLE|\n|concepts {\\n  id:...|  10/26/% 12:43:   %5|    NrOaWbbfH6QEVFBW|   10/26/% 12:43:   %5|           mansi_k|                 t11|\n|concepts {\\n  id:...|  10/26/% 12:43:   %5|    8sH9gt43eqx3rBYF|   10/26/% 12:43:   %5|           mansi_k|                 t21|\n|concepts {\\n  id:...|  10/26/% 12:43:   %5|    fc9VQUXheCJaZu28|   10/26/% 12:43:   %5|           mansi_k|                 t31|\n+--------------------+---------------------+--------------------+----------------------+------------------+--------------------+\n\n"
      ]
     }
    ],
@@ -414,7 +384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -429,13 +399,14 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-11-17 16:17:18 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m2023-11-17 16:17:18\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=806052;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=260277;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001B[2;36m2023-11-17 16:17:18\u001B[0m\u001B[2;36m \u001B[0m\u001B[34mINFO    \u001B[0m INFO:py4j.clientserver:Received command c on object id p0          \u001B]8;id=806052;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001B\\\u001B[2mclientserver.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=260277;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001B\\\u001B[2m575\u001B[0m\u001B]8;;\u001B\\\n"
       ]
      },
      "metadata": {},
@@ -471,7 +442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -486,42 +457,30 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">2023-11-17 16:17:44 </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> INFO:py4j.clientserver:Received command c on object id p0          <a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">clientserver.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">575</span></a>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m2023-11-17 16:17:44\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m INFO:py4j.clientserver:Received command c on object id p0          \u001b]8;id=605835;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001b\\\u001b[2mclientserver.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=113786;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001b\\\u001b[2m575\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001B[2;36m2023-11-17 16:17:44\u001B[0m\u001B[2;36m \u001B[0m\u001B[34mINFO    \u001B[0m INFO:py4j.clientserver:Received command c on object id p0          \u001B]8;id=605835;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\u001B\\\u001B[2mclientserver.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=113786;file:///databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py#575\u001B\\\u001B[2m575\u001B[0m\u001B]8;;\u001B\\\n"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
     },
     {
+     "output_type": "stream",
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "+--------------------+---------------------+--------------------+----------------------+------------------+--------------------+\n",
-      "|          annotation|annotation_created_at|       annotation_id|annotation_modified_at|annotation_user_id|            input_id|\n",
-      "+--------------------+---------------------+--------------------+----------------------+------------------+--------------------+\n",
-      "|concepts {\\n  id:...|  11/17/% 13:43:   %5|1e6224252c324b04b...|   11/17/% 13:43:   %5|           mansi_k|5a1d54db53403352f...|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:45:   %5|190e2387564c416f8...|   10/26/% 12:45:   %5|           mansi_k|    PKaXcNjJ5fJ7wZqR|\n",
-      "|text {\\n  url: \"h...|  10/30/% 15:04:   %5|f602439fd7b14aa6b...|   10/30/% 15:04:   %5|           mansi_k|    XFmGD0xHlNXgGIXF|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:43:   %5|    NrOaWbbfH6QEVFBW|   10/26/% 12:43:   %5|           mansi_k|                 t11|\n",
-      "|concepts {\\n  id:...|  11/17/% 13:51:   %5|d0bb5fea2d8c4f4e8...|   11/17/% 13:51:   %5|           mansi_k|fe3f42364969fe544...|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:45:   %5|22757a0e73fa4cac8...|   10/26/% 12:45:   %5|           mansi_k|    IYMxwJq0jjwJguLE|\n",
-      "|concepts {\\n  id:...|  10/30/% 13:02:   %5|    TVFLGTHd8NryFWsY|   10/30/% 13:02:   %5|           mansi_k|    Ak1n8DZ1l1RWKATv|\n",
-      "|text {\\n  url: \"h...|  10/30/% 12:46:   %5|125b80fb08604e36a...|   10/30/% 12:46:   %5|           mansi_k|    Ak1n8DZ1l1RWKATv|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:43:   %5|    8sH9gt43eqx3rBYF|   10/26/% 12:43:   %5|           mansi_k|                 t21|\n",
-      "|concepts {\\n  id:...|  10/26/% 12:43:   %5|    fc9VQUXheCJaZu28|   10/26/% 12:43:   %5|           mansi_k|                 t31|\n",
-      "+--------------------+---------------------+--------------------+----------------------+------------------+--------------------+\n",
-      "\n"
+      "+--------------------+---------------------+--------------------+----------------------+------------------+--------------------+\n|          annotation|annotation_created_at|       annotation_id|annotation_modified_at|annotation_user_id|            input_id|\n+--------------------+---------------------+--------------------+----------------------+------------------+--------------------+\n|concepts {\\n  id:...|  11/17/% 13:43:   %5|1e6224252c324b04b...|   11/17/% 13:43:   %5|           mansi_k|5a1d54db53403352f...|\n|concepts {\\n  id:...|  10/26/% 12:45:   %5|190e2387564c416f8...|   10/26/% 12:45:   %5|           mansi_k|    PKaXcNjJ5fJ7wZqR|\n|text {\\n  url: \"h...|  10/30/% 15:04:   %5|f602439fd7b14aa6b...|   10/30/% 15:04:   %5|           mansi_k|    XFmGD0xHlNXgGIXF|\n|concepts {\\n  id:...|  10/26/% 12:43:   %5|    NrOaWbbfH6QEVFBW|   10/26/% 12:43:   %5|           mansi_k|                 t11|\n|concepts {\\n  id:...|  11/17/% 13:51:   %5|d0bb5fea2d8c4f4e8...|   11/17/% 13:51:   %5|           mansi_k|fe3f42364969fe544...|\n|concepts {\\n  id:...|  10/26/% 12:45:   %5|22757a0e73fa4cac8...|   10/26/% 12:45:   %5|           mansi_k|    IYMxwJq0jjwJguLE|\n|concepts {\\n  id:...|  10/30/% 13:02:   %5|    TVFLGTHd8NryFWsY|   10/30/% 13:02:   %5|           mansi_k|    Ak1n8DZ1l1RWKATv|\n|text {\\n  url: \"h...|  10/30/% 12:46:   %5|125b80fb08604e36a...|   10/30/% 12:46:   %5|           mansi_k|    Ak1n8DZ1l1RWKATv|\n|concepts {\\n  id:...|  10/26/% 12:43:   %5|    8sH9gt43eqx3rBYF|   10/26/% 12:43:   %5|           mansi_k|                 t21|\n|concepts {\\n  id:...|  10/26/% 12:43:   %5|    fc9VQUXheCJaZu28|   10/26/% 12:43:   %5|           mansi_k|                 t31|\n+--------------------+---------------------+--------------------+----------------------+------------------+--------------------+\n\n"
      ]
     }
    ],
    "source": [
-    "df_delta = spark.read.format(\"delta\").load(delta_path)\n",
+    "df_delta = spark.read.table(delta_path)\n",
     "df_delta.show()"
    ]
   }


### PR DESCRIPTION
Modified the way we read and write into Delta tables. 

1. Used saveAsTable('table_name') to write the delta table instead of saving it into a Volume path. This creates an actual. delta table in the provided schema and can be viewed from the Unity catalog.

2. Used read.table('table_name') to read the delta table instead of reading the delta file from the Volume

3. Added function to convert Dataframe to Delta table in Example notebook